### PR TITLE
Fixed TX gain setting and adjusted IIO buffer to stop samples being lost before TX

### DIFF
--- a/PlutoSDR_Registation.cpp
+++ b/PlutoSDR_Registation.cpp
@@ -1,9 +1,11 @@
 #include "SoapyPlutoSDR.hpp"
 #include <SoapySDR/Registry.hpp>
 
+static std::vector<SoapySDR::Kwargs> results;
 static std::vector<SoapySDR::Kwargs> find_PlutoSDR(const SoapySDR::Kwargs &args){
 
-	std::vector<SoapySDR::Kwargs> results;
+	if(!results.empty())
+	  return results;
 
 	ssize_t ret=0;
 	iio_context *ctx=nullptr;

--- a/PlutoSDR_Settings.cpp
+++ b/PlutoSDR_Settings.cpp
@@ -51,7 +51,11 @@ SoapyPlutoSDR::~SoapyPlutoSDR(void){
 		iio_channel_attr_write_longlong(iio_device_find_channel(tx_dev, "voltage0", true),"sampling_frequency", samplerate);
 	}
 
-	if(ctx)iio_context_destroy(ctx);
+	if(ctx)
+	{
+		iio_context_destroy(ctx);
+		ctx = nullptr;
+	}
 
 
 }
@@ -274,7 +278,7 @@ double SoapyPlutoSDR::getGain( const int direction, const size_t channel, const 
 SoapySDR::Range SoapyPlutoSDR::getGainRange( const int direction, const size_t channel, const std::string &name ) const
 {
 	if(direction==SOAPY_SDR_RX)
-		(SoapySDR::Range(0, 76));
+		return(SoapySDR::Range(0, 73));
 	return(SoapySDR::Range(0,89));
 
 }

--- a/PlutoSDR_Settings.cpp
+++ b/PlutoSDR_Settings.cpp
@@ -231,7 +231,7 @@ void SoapyPlutoSDR::setGain( const int direction, const size_t channel, const do
 
 	if(direction==SOAPY_SDR_TX){
 
-		gain = 89 - gain;
+		gain = gain - 89;
 		iio_channel_attr_write_longlong(iio_device_find_channel(dev, "voltage0", true),"hardwaregain", gain);
 
 	}

--- a/PlutoSDR_Settings.cpp
+++ b/PlutoSDR_Settings.cpp
@@ -3,28 +3,32 @@
 #include <ad9361.h>
 #endif
 
+static iio_context *ctx = nullptr; 
 SoapyPlutoSDR::SoapyPlutoSDR( const SoapySDR::Kwargs &args ):
-	ctx(nullptr), dev(nullptr), rx_dev(nullptr),tx_dev(nullptr), decimation(false), interpolation(false), rx_stream(nullptr)
+	dev(nullptr), rx_dev(nullptr),tx_dev(nullptr), decimation(false), interpolation(false), rx_stream(nullptr)
 {
 
 	if (args.count("label") != 0)
 		SoapySDR_logf( SOAPY_SDR_INFO, "Opening %s...", args.at("label").c_str());
 
+	if(ctx == nullptr)
+	{
+	  if(args.count("uri") != 0) {
 
-	if(args.count("uri") != 0) {
+		  ctx = iio_create_context_from_uri(args.at("uri").c_str());
 
-		ctx = iio_create_context_from_uri(args.at("uri").c_str());
-
-	}else if(args.count("hostname")!=0){
-		ctx = iio_create_network_context(args.at("hostname").c_str());
-	}else{
-		ctx = iio_create_default_context();
+	  }else if(args.count("hostname")!=0){
+		  ctx = iio_create_network_context(args.at("hostname").c_str());
+	  }else{
+		  ctx = iio_create_default_context();
+	  }
 	}
 
 	if (ctx == nullptr) {
 		SoapySDR_logf(SOAPY_SDR_ERROR, "not device found.");
 		throw std::runtime_error("not device found");
 	}
+
 	dev = iio_context_find_device(ctx, "ad9361-phy");
 	rx_dev = iio_context_find_device(ctx, "cf-ad9361-lpc");
 	tx_dev = iio_context_find_device(ctx, "cf-ad9361-dds-core-lpc");

--- a/PlutoSDR_Streaming.cpp
+++ b/PlutoSDR_Streaming.cpp
@@ -435,6 +435,11 @@ tx_streamer::tx_streamer(const iio_device *_dev, const std::string &_format, con
 
 	}
 	buf = iio_device_create_buffer(dev, 4096, false);
+	if (!buf) {
+		SoapySDR_logf(SOAPY_SDR_ERROR, "Unable to create buffer!");
+		throw std::runtime_error("Unable to create buffer!");
+	}
+
 	format = _format;
 }
 
@@ -458,19 +463,8 @@ int tx_streamer::send(	const void * const *buffs,
 	size_t items = std::min(4096, (int)numElems);
 
 	if (buffer.size() != items) {
-		if (buf) 
-		{
-			  //iio_buffer_destroy(buf);
-		}
-
 		buffer.reserve(items);
 		buffer.resize(items);
-		//buf = iio_device_create_buffer(dev, buffer.size(), false);
-		if (!buf) {
-			SoapySDR_logf(SOAPY_SDR_ERROR, "Unable to create buffer!");
-			throw std::runtime_error("Unable to create buffer!");
-		}
-
 	}
 
 	for (unsigned int i = 0; i < channel_list.size(); i++) {

--- a/SoapyPlutoSDR.hpp
+++ b/SoapyPlutoSDR.hpp
@@ -261,7 +261,6 @@ class SoapyPlutoSDR : public SoapySDR::Device{
 
 	private:
 
-		iio_context *ctx;
 		iio_device *dev;
 		iio_device *rx_dev;
 		iio_device *tx_dev;
@@ -269,3 +268,4 @@ class SoapyPlutoSDR : public SoapySDR::Device{
 		bool decimation, interpolation;
 		std::shared_ptr<rx_streamer> rx_stream;
 };
+


### PR DESCRIPTION
Pluto transmit gain setting expects a negative number (attenuation in dB) so the sent value is now negative.
The code which destroys the IIO buffer every time new samples are sent can stop the transmission with GNU radio from time to time. To avoid this, the buffer is created once at startup and never destroyed until shutdown. This method works fine with GNU radio, gr-osmosdr sinks and SoapySDR.

Let me know what you think.